### PR TITLE
values of example usage updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ cp.collection = ['ffffff'])
 cp.past_threshold?('000000') # [true]
 
 cp.collection = ['000001', '000002', 'ffffff'])
-cp.thresholds('000003') # [3.3166247903554, 1.4142135623730951, 762.3437544835007]
-```
+cp.thresholds('000003') # [0.00832, 0.00412, 0.99948]
 
 A failure case returns an array with two elements: `false`, and the collection of colors that failed the threshold. Success cases return an array with one element: `true`. This is designed to make it easy to call `.first` on the result to validate it.
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ require 'color-proximity'
 cp = ColorProximity.new(0.5, ['000000'])
 cp.past_threshold?('000000') # [false, ['000000']]
 
-cp.collection = ['ffffff'])
+cp.collection = (['ffffff'])
 cp.past_threshold?('000000') # [true]
 
-cp.collection = ['000001', '000002', 'ffffff'])
+cp.collection = (['000001', '000002', 'ffffff'])
 cp.thresholds('000003') # [0.00832, 0.00412, 0.99948]
 
 A failure case returns an array with two elements: `false`, and the collection of colors that failed the threshold. Success cases return an array with one element: `true`. This is designed to make it easy to call `.first` on the result to validate it.


### PR DESCRIPTION
hi, I think the values in example usage are not correct. Possibly this is due to a change of upstream dependency color_difference.
These are the values that I get executing the script in repl.it.
Also added missing parentheses.